### PR TITLE
Move footnote so it doesn't look like an exponent

### DIFF
--- a/tpus.md
+++ b/tpus.md
@@ -157,7 +157,7 @@ TPU v5e and Trillium pods consist of a single `16x16` 2D torus with wraparounds 
 **ICI is very fast relative to DCN, but is still slower than HBM bandwidth.** For instance, a [TPU v5p](https://cloud.google.com/tpu/docs/v5p#system_architecture) has:
 
 * `2.5e12` bytes/s (2.5 TB/s) of HBM bandwidth per chip.
-* `9e10` bytes/s (90<d-footnote>The page above lists 100 GB/s of bandwidth, which is slightly different from what's listed here. TPU ICI links have slightly different bandwidths depending on the operation being performed. You can generally use the numbers in this doc without worry.</d-footnote> GB/s) of ICI bandwidth per axis, with 3 axes per chip. 
+* `9e10` bytes/s (90 GB/s) of ICI bandwidth per axis, with 3 axes per chip<d-footnote>The page above lists 100 GB/s of bandwidth, which is slightly different from what's listed here. TPU ICI links have slightly different bandwidths depending on the operation being performed. You can generally use the numbers in this doc without worry.</d-footnote>.
 * `2.5e10` bytes/s (25 GB/s) of DCN (egress) bandwidth per host. Since we typically have 8 TPUs per host, this is really closer to `3.1e9` bytes / s / chip.
 
 This means that when we split models across multiple chips, we need to be careful to avoid bottlenecking the MXU with slower cross-device communication.


### PR DESCRIPTION
having the footnote right next to a number makes it seem like an exponent