### PR TITLE
Fix code blocks, headings, and footnotes not expanding to full page width

### DIFF
--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -173,17 +173,12 @@ d-appendix {
     grid-column: page !important;
   }
 
-  d-article p,
-  d-article ul,
-  d-article ol,
-  d-article blockquote,
-  d-article pre,
-  d-article table,
-  d-article details,
-  d-article figure,
-  d-article img,
-  d-article .l-body,
-  d-article .l-text {
+  d-article > * {
+    grid-column: page !important;
+  }
+
+  d-appendix > *,
+  d-footnote-list > * {
     grid-column: page !important;
   }
 }


### PR DESCRIPTION
The responsive rule at <999px listed specific element selectors (p, ul, pre, etc.) to expand to `grid-column: page` when the TOC is hidden. This missed several element types:

- **Code blocks**: Jekyll wraps fenced code in `div.highlighter-rouge` wrappers, but only `pre` was in the selector list. Since `grid-column` only applies to grid items (direct children of the grid container), the wrapper div stayed at `text` width.
- **Headings**: `h1`–`h6` were not listed, so `.next-section` boxes (`h3`) didn't expand.
- **Footnotes**: `d-footnote-list` items in the appendix had no responsive override.

### Fix

Replace the explicit element list with `d-article > *` to catch all direct children, and add `d-appendix > *` and `d-footnote-list > *` for the appendix.