### PR TITLE
Fix broken LaTeX/author rendering: jsonify d-front-matter description

### DIFF
--- a/_layouts/distill.liquid
+++ b/_layouts/distill.liquid
@@ -22,8 +22,8 @@
 <d-front-matter>
   <script async type="text/json">
       {
-            "title": "{{ page.title }}",
-            "description": "{{ page.description }}",
+            "title": {{ page.title | jsonify }},
+            "description": {{ page.description | jsonify }},
             "published": "{{ page.date | date: '%B %d, %Y' }}",
             "authors": [
               {% for author in page.authors %}


### PR DESCRIPTION
Fixes the broken LaTeX rendering and missing author byline on the live site.

**Root cause:** `_layouts/distill.liquid` interpolates `page.title` and `page.description` directly into the `<d-front-matter>` JSON block:

```liquid
"description": "{{ page.description }}",
```

When the front-matter `description:` contains a straight double quote (introduced when smart quotes were normalized in #106 — e.g. `These "roofline" constraints` in roofline.md, `(or "shard")` in sharding.md, and the three quoted phrases in index.md), it breaks the JSON:

```
Uncaught SyntaxError: Expected ',' or '}' after property value in JSON at position 504
```

The malformed `<d-front-matter>` JSON crashes the distill template component, which is what wires up KaTeX delimiters (`$...$`, `$$...$$`) and renders the author byline. So the symptom is unrendered inline LaTeX and a missing author list across the whole site.

**Fix:** Use Liquid's `jsonify` filter, which produces a fully-quoted, properly-escaped JSON string regardless of the value's content. Applied to both `description` and `title` (the latter doesn't currently break anything but had the same vulnerability).

Verified that the post-fix `jsonify` output round-trips cleanly through a JSON parser for all three affected pages.