### PR TITLE
Make light/dark theme toggle instant

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -897,13 +897,12 @@ code {
   padding: 3px 3px;
 }
 
-// Transitioning Themes
+// Transitioning Themes — switch instantly, no fade
 html.transition,
 html.transition *,
 html.transition *:before,
 html.transition *:after {
-  transition: all 750ms !important;
-  transition-delay: 0 !important;
+  transition: none !important;
 }
 
 // Extra Markdown style (post Customization)


### PR DESCRIPTION
The theme toggle (light/dark mode) currently fades over 750ms via a `transition: all 750ms !important` rule applied to every element while `html.transition` is set. Replace it with `transition: none !important` so the colors flip instantly.

The `html.transition` class is still added by `transTheme()` in `assets/js/theme.js` during the switch, so this also has the side effect of *suppressing* any in-flight element transitions (e.g. tab/button hover effects) during the swap, which prevents partial fades. After the switch completes the class is removed and normal hover transitions resume.