### PR TITLE
Add opt-in Tufte-style margin sidenotes for footnotes

### DIFF
--- a/_includes/distill_scripts.liquid
+++ b/_includes/distill_scripts.liquid
@@ -159,6 +159,9 @@
 <!-- Jupyter Open External Links New Tab -->
 <script defer src="{{ '/assets/js/jupyter_new_tab.js' | relative_url | bust_file_cache }}"></script>
 
+<!-- Tufte-style margin sidenotes for d-footnote -->
+<script defer src="{{ '/assets/js/sidenotes.js' | relative_url | bust_file_cache }}"></script>
+
 <!-- Removed Badges -->
 
 {% if site.enable_math %}

--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -84,6 +84,15 @@
   </script>
 {% endif %}
 
+<!-- Set Tufte-mode class before first paint to avoid layout flicker -->
+<script>
+  try {
+    if (localStorage.getItem("tufte-sidenotes-enabled") === "1") {
+      document.documentElement.classList.add("tufte-mode");
+    }
+  } catch (e) {}
+</script>
+
 {% if page.map %}
   <!-- GeoJSON support via Leaflet -->
   <link

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -485,6 +485,7 @@ d-article.has-sidenotes {
     left: 0;
     right: 0;
     pointer-events: auto;
+    cursor: pointer;
     font-size: 0.8em;
     line-height: 1.5em;
     color: var(--global-text-color-light, rgba(0, 0, 0, 0.6));

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -507,8 +507,8 @@ d-article.has-sidenotes {
     margin-right: 1px;
   }
 
-  // Hovering the in-text marker or the sidenote nudges the pair's number color.
+  // Hovering the in-text marker or the sidenote brightens the pair's number.
   .tufte-sidenote.tufte-hover .tufte-sidenote-number {
-    color: #0a58ca;
+    color: #4da3ff;
   }
 }

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -507,10 +507,10 @@ d-article.has-sidenotes {
     margin-right: 1px;
   }
 
-  // Hovering the in-text marker or the sidenote brightens the pair's number.
-  // text-shadow gives a visible glow on a tiny glyph without any layout shift.
+  // Hovering the in-text marker or the sidenote flips the pair's number to
+  // orange — a hue shift is far more visible on a tiny glyph than any
+  // same-hue lightness change, and a pure color change doesn't shift layout.
   .tufte-sidenote.tufte-hover .tufte-sidenote-number {
-    color: #66b3ff;
-    text-shadow: 0 0 6px rgba(77, 163, 255, 0.9);
+    color: #ff8c00;
   }
 }

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -474,9 +474,9 @@ d-article.has-sidenotes {
     bottom: 0;
     left: 0;
     right: 0;
-    max-width: 320px;
+    max-width: 300px;
     padding-left: 20px; // breathing room between body text and sidenotes
-    padding-right: 16px;
+    padding-right: 24px;
     box-sizing: border-box;
     pointer-events: none; // don't block clicks/scroll on the white margin
   }

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -519,13 +519,12 @@ d-article.has-sidenotes {
     // centered Bootstrap .container; give the nav the same grid template and
     // pin the container to text-start so the brand and links share the text
     // column's left edge.
-    #navbar {
+    // Elements that don't use the distill grid (navbar's Bootstrap container,
+    // giscus comments) get the same column template applied directly so their
+    // content can be pinned to text-start and line up with the body.
+    #navbar,
+    #giscus_thread {
       display: grid;
-      grid-template-columns: inherit;
-      // navbar isn't in the grid stack above, so it won't inherit the columns.
-      // Re-apply them here (1000px and 1180px versions are the same shape, so
-      // one definition with the 1180px sizes is close enough; the 1000-1179px
-      // band is narrow).
       grid-template-columns:
         [screen-start] minmax(24px, 0.6fr)
         [page-start text-start]
@@ -537,12 +536,22 @@ d-article.has-sidenotes {
       grid-column-gap: 32px;
       padding-left: 0;
       padding-right: 0;
+    }
 
-      > .container {
+    #navbar > .container {
+      grid-column: text-start / page-end;
+      max-width: none;
+      margin: 0;
+      padding-left: 0;
+    }
+
+    #giscus_thread {
+      // The include sets inline max-width/margin; override them.
+      max-width: none !important;
+      margin: 0 !important;
+
+      > * {
         grid-column: text-start / page-end;
-        max-width: none;
-        margin: 0;
-        padding-left: 0;
       }
     }
   }

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -470,21 +470,115 @@ d-article.has-sidenotes {
     display: block;
     grid-column: gutter-start / screen-end;
     position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    max-width: 300px;
-    padding-left: 20px; // breathing room between body text and sidenotes
-    padding-right: 24px;
-    box-sizing: border-box;
+    inset: 0;
     pointer-events: none; // don't block clicks/scroll on the white margin
+  }
+
+  // --- Tufte-mode layout experiment ---------------------------------------
+  // When the "Tufte footnotes" toggle is on, drop the left TOC and slide the
+  // text column left to where the TOC was, freeing up a wider right gutter
+  // for sidenotes (a la siboehm.com/articles/22/CUDA-MMM). This works by
+  // redefining where the named [text-start]/[text-end]/[gutter-*] lines fall
+  // in the distill grid, so everything that places itself with
+  // `grid-column: text` (article body, title, byline, appendix) moves left
+  // automatically without per-element overrides.
+  html.tufte-mode {
+    .base-grid,
+    distill-header,
+    d-title,
+    d-abstract,
+    d-article,
+    d-appendix,
+    distill-appendix,
+    d-byline,
+    d-footnote-list,
+    d-citation-list,
+    distill-footer {
+      // Asymmetric outer margins (0.6fr left, 1fr right) pull the text column
+      // toward the left edge a la siboehm.com, freeing more room on the right.
+      grid-template-columns:
+        [screen-start] minmax(24px, 0.6fr)
+        [page-start kicker-start middle-start text-start kicker-end]
+        62px 62px 62px 62px 62px 62px 62px 62px
+        [text-end gutter-start]
+        62px 62px 62px 62px
+        [middle-end page-end gutter-end]
+        1fr [screen-end];
+    }
+
+    d-article d-contents {
+      display: none;
+    }
+
+    .tufte-sidenote {
+      left: 70px;
+      max-width: 380px;
+    }
+
+    // Align the navbar with the shifted text column. The navbar uses a
+    // centered Bootstrap .container; give the nav the same grid template and
+    // pin the container to text-start so the brand and links share the text
+    // column's left edge.
+    #navbar {
+      display: grid;
+      grid-template-columns: inherit;
+      // navbar isn't in the grid stack above, so it won't inherit the columns.
+      // Re-apply them here (1000px and 1180px versions are the same shape, so
+      // one definition with the 1180px sizes is close enough; the 1000-1179px
+      // band is narrow).
+      grid-template-columns:
+        [screen-start] minmax(24px, 0.6fr)
+        [page-start text-start]
+        60px 60px 60px 60px 60px 60px 60px 60px
+        [text-end gutter-start]
+        60px 60px 60px 60px
+        [page-end gutter-end]
+        1fr [screen-end];
+      grid-column-gap: 32px;
+      padding-left: 0;
+      padding-right: 0;
+
+      > .container {
+        grid-column: text-start / page-end;
+        max-width: none;
+        margin: 0;
+        padding-left: 0;
+      }
+    }
+  }
+}
+
+@media (min-width: 1180px) {
+  html.tufte-mode {
+    .base-grid,
+    distill-header,
+    d-title,
+    d-abstract,
+    d-article,
+    d-appendix,
+    distill-appendix,
+    d-byline,
+    d-footnote-list,
+    d-citation-list,
+    distill-footer {
+      grid-template-columns:
+        [screen-start] minmax(24px, 0.6fr)
+        [page-start kicker-start middle-start text-start kicker-end]
+        60px 60px 60px 60px 60px 60px 60px 60px
+        [text-end gutter-start]
+        60px 60px 60px 60px
+        [middle-end page-end gutter-end]
+        1fr [screen-end];
+    }
   }
 
   .tufte-sidenote {
     position: absolute;
-    left: 0;
-    right: 0;
+    // left/right position within the gutter container; abspos ignores
+    // container padding, so the gap from body text is set here.
+    left: 20px;
+    right: 24px;
+    max-width: 260px;
     pointer-events: auto;
     cursor: pointer;
     font-size: 0.8em;

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -507,13 +507,8 @@ d-article.has-sidenotes {
     margin-right: 1px;
   }
 
-  // Hovering the in-text marker or the sidenote flashes the pair.
-  .tufte-sidenote.tufte-hover {
-    color: var(--global-text-color, rgba(0, 0, 0, 0.9));
-    .tufte-sidenote-number {
-      background: rgba(0, 123, 255, 0.18);
-      border-radius: 3px;
-      padding: 0 2px;
-    }
+  // Hovering the in-text marker or the sidenote nudges the pair's number color.
+  .tufte-sidenote.tufte-hover .tufte-sidenote-number {
+    color: #0a58ca;
   }
 }

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -515,3 +515,63 @@ d-article.has-sidenotes {
     color: #ff8c00;
   }
 }
+
+// Floating settings control for sidenotes. Hidden below the breakpoint where
+// sidenotes are possible; sits below the fixed nav bar on the right.
+.tufte-settings {
+  display: none;
+}
+
+@media (min-width: 1000px) {
+  .tufte-settings {
+    display: block;
+    position: fixed;
+    top: 70px;
+    right: 18px;
+    z-index: 100;
+    font-size: 0.85rem;
+  }
+
+  .tufte-settings-btn {
+    width: 34px;
+    height: 34px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--global-text-color-light, rgba(0, 0, 0, 0.6));
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+      color: var(--global-text-color, rgba(0, 0, 0, 0.9));
+    }
+  }
+
+  .tufte-settings-panel {
+    position: absolute;
+    top: 36px;
+    right: 0;
+    min-width: 160px;
+    padding: 8px 10px;
+    border-radius: 4px;
+    background: var(--global-bg-color, #fff);
+    color: var(--global-text-color-light, rgba(0, 0, 0, 0.7));
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+
+    label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin: 0;
+      cursor: pointer;
+      user-select: none;
+    }
+
+    input[type="checkbox"] {
+      margin: 0;
+    }
+  }
+}

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -441,3 +441,79 @@ d-hover-box ul {
   white-space: nowrap;
   font-weight: 500;
 }
+
+// -----------------------------------------------------------------------------
+// Tufte-style margin sidenotes (see assets/js/sidenotes.js).
+//
+// On wide viewports each <d-footnote> gets a copy of its content placed in the
+// right gutter, vertically aligned with the marker. The container is positioned
+// by JS using the gutter grid column as a horizontal reference. On narrower
+// viewports (where d-article > * spans `page` and the gutter disappears) the
+// JS removes the container and the native d-hover-box popup takes over.
+// -----------------------------------------------------------------------------
+
+d-article.has-sidenotes {
+  position: relative;
+}
+
+.tufte-sidenotes {
+  display: none;
+}
+
+@media (min-width: 1000px) {
+  // Occupy the right gutter (and the screen margin beyond it) for the full
+  // height of the article. With grid-column set, the abspos containing block
+  // is that grid area, so left/right: 0 fill it horizontally and top/bottom: 0
+  // fill the article vertically (grid-row: auto on an abspos item spans the
+  // padding box).
+  d-article > .tufte-sidenotes {
+    display: block;
+    grid-column: gutter-start / screen-end;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    max-width: 300px;
+    padding-right: 16px;
+    box-sizing: border-box;
+    pointer-events: none; // don't block clicks/scroll on the white margin
+  }
+
+  .tufte-sidenote {
+    position: absolute;
+    left: 0;
+    right: 0;
+    pointer-events: auto;
+    font-size: 0.8em;
+    line-height: 1.5em;
+    color: var(--global-text-color-light, rgba(0, 0, 0, 0.6));
+
+    a {
+      color: inherit;
+    }
+
+    // Math and code in footnotes can be wide; keep them from spilling out.
+    .katex,
+    code {
+      font-size: 0.95em;
+    }
+    overflow-wrap: break-word;
+  }
+
+  .tufte-sidenote-number {
+    color: #007bff; // matches the d-footnote marker color
+    font-weight: 600;
+    margin-right: 1px;
+  }
+
+  // Hovering the in-text marker or the sidenote flashes the pair.
+  .tufte-sidenote.tufte-hover {
+    color: var(--global-text-color, rgba(0, 0, 0, 0.9));
+    .tufte-sidenote-number {
+      background: rgba(0, 123, 255, 0.18);
+      border-radius: 3px;
+      padding: 0 2px;
+    }
+  }
+}

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -474,7 +474,8 @@ d-article.has-sidenotes {
     bottom: 0;
     left: 0;
     right: 0;
-    max-width: 300px;
+    max-width: 320px;
+    padding-left: 20px; // breathing room between body text and sidenotes
     padding-right: 16px;
     box-sizing: border-box;
     pointer-events: none; // don't block clicks/scroll on the white margin

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -523,6 +523,8 @@ d-article.has-sidenotes {
 }
 
 @media (min-width: 1000px) {
+  // Absolute (not fixed) so it sits at the top of the page and scrolls away
+  // once you read past it.
   .tufte-settings {
     display: block;
     position: absolute;

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -551,7 +551,7 @@ d-article.has-sidenotes {
       margin: 0 !important;
 
       > * {
-        grid-column: text-start / page-end;
+        grid-column: text;
       }
     }
   }

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -508,7 +508,9 @@ d-article.has-sidenotes {
   }
 
   // Hovering the in-text marker or the sidenote brightens the pair's number.
+  // text-shadow gives a visible glow on a tiny glyph without any layout shift.
   .tufte-sidenote.tufte-hover .tufte-sidenote-number {
-    color: #4da3ff;
+    color: #66b3ff;
+    text-shadow: 0 0 6px rgba(77, 163, 255, 0.9);
   }
 }

--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -525,7 +525,7 @@ d-article.has-sidenotes {
 @media (min-width: 1000px) {
   .tufte-settings {
     display: block;
-    position: fixed;
+    position: absolute;
     top: 70px;
     right: 18px;
     z-index: 100;

--- a/assets/js/sidenotes.js
+++ b/assets/js/sidenotes.js
@@ -52,7 +52,9 @@
           const style = document.createElement("style");
           style.setAttribute("data-sidenote", "");
           style.textContent =
-            "sup span." + HOVER_CLASS + "{color:#4da3ff;}";
+            "sup span." +
+            HOVER_CLASS +
+            "{color:#66b3ff;text-shadow:0 0 6px rgba(77,163,255,.9);}";
           root.appendChild(style);
         }
         hover.style.display = "none";

--- a/assets/js/sidenotes.js
+++ b/assets/js/sidenotes.js
@@ -52,7 +52,7 @@
           const style = document.createElement("style");
           style.setAttribute("data-sidenote", "");
           style.textContent =
-            "sup span." + HOVER_CLASS + "{color:#0a58ca;}";
+            "sup span." + HOVER_CLASS + "{color:#4da3ff;}";
           root.appendChild(style);
         }
         hover.style.display = "none";

--- a/assets/js/sidenotes.js
+++ b/assets/js/sidenotes.js
@@ -1,0 +1,240 @@
+// Tufte-style margin sidenotes for d-footnote.
+//
+// On wide viewports (>= 1000px, where the d-article right gutter exists),
+// each <d-footnote> gets a sidenote in the right margin, vertically aligned
+// with the text line containing its marker. The native d-hover-box popup is
+// suppressed; hovering either the in-text marker or the sidenote highlights
+// the pair. On narrower viewports the sidenotes are removed and the popup is
+// restored.
+
+(function () {
+  "use strict";
+
+  const WIDE_QUERY = "(min-width: 1000px)";
+  const SIDENOTE_GAP = 12; // min vertical gap (px) between stacked sidenotes
+  const CONTAINER_CLASS = "tufte-sidenotes";
+  const NOTE_CLASS = "tufte-sidenote";
+  const HOVER_CLASS = "tufte-hover";
+
+  let container = null;
+  let pairs = []; // [{fn, note, off}]
+  let raf = null;
+  let resizeObs = null;
+  let lastArticleHeight = -1;
+
+  function isWide() {
+    return window.matchMedia(WIDE_QUERY).matches;
+  }
+
+  function getArticle() {
+    return document.querySelector("d-article");
+  }
+
+  function getFootnotes(article) {
+    return Array.from(article.querySelectorAll("d-footnote"));
+  }
+
+  // d-hover-box.show() force-sets style.display = "block", so simply hiding
+  // the box doesn't stick. Instead, neuter show() while sidenotes are active
+  // and restore the original when they aren't.
+  function setPopupSuppressed(footnotes, suppressed) {
+    for (const fn of footnotes) {
+      const root = fn.shadowRoot;
+      if (!root) continue;
+      const hover = root.querySelector("d-hover-box");
+      if (!hover) continue;
+      if (suppressed) {
+        if (!hover.__sidenoteShow) {
+          hover.__sidenoteShow = hover.show;
+          hover.show = function () {};
+          // Inject a hover style into the shadow root so we can flash the
+          // marker number from outside (regular CSS can't pierce shadow DOM).
+          const style = document.createElement("style");
+          style.setAttribute("data-sidenote", "");
+          style.textContent =
+            "sup span." +
+            HOVER_CLASS +
+            "{background:rgba(0,123,255,.18);border-radius:3px;padding:0 2px;}";
+          root.appendChild(style);
+        }
+        hover.style.display = "none";
+      } else if (hover.__sidenoteShow) {
+        hover.show = hover.__sidenoteShow;
+        delete hover.__sidenoteShow;
+        hover.style.display = "";
+      }
+    }
+  }
+
+  function getFootnoteNumber(fn, index) {
+    const root = fn.shadowRoot;
+    if (root) {
+      const span = root.querySelector("sup span");
+      if (span && span.textContent) return span.textContent;
+    }
+    return String(index + 1);
+  }
+
+  // A footnote inside a collapsed <details> (or otherwise hidden) should not
+  // produce a floating sidenote.
+  function isVisible(el) {
+    if (!el.isConnected) return false;
+    if (el.closest("details:not([open])")) return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 || r.height > 0;
+  }
+
+  // Top of the text line containing the marker, relative to the article.
+  // d-footnote is inline; its box height equals the line-height of the
+  // surrounding text (the sup is position:relative so it doesn't grow the
+  // box), so rect.top is the line top.
+  function lineTop(fn, articleTop) {
+    return fn.getBoundingClientRect().top - articleTop;
+  }
+
+  function setHoverPair(fn, note, on) {
+    note.classList.toggle(HOVER_CLASS, on);
+    fn.classList.toggle(HOVER_CLASS, on);
+    // The visible marker number is in shadow DOM; toggle a class on it too so
+    // the highlight can reach it via :host().
+    const root = fn.shadowRoot;
+    if (root) {
+      const span = root.querySelector("sup span");
+      if (span) span.classList.toggle(HOVER_CLASS, on);
+    }
+  }
+
+  function bindHoverPair(fn, note) {
+    const on = () => setHoverPair(fn, note, true);
+    const off = () => setHoverPair(fn, note, false);
+    fn.addEventListener("mouseenter", on);
+    fn.addEventListener("mouseleave", off);
+    note.addEventListener("mouseenter", on);
+    note.addEventListener("mouseleave", off);
+    return () => {
+      fn.removeEventListener("mouseenter", on);
+      fn.removeEventListener("mouseleave", off);
+      note.removeEventListener("mouseenter", on);
+      note.removeEventListener("mouseleave", off);
+      setHoverPair(fn, note, false);
+    };
+  }
+
+  function clearSidenotes(article, footnotes) {
+    for (const p of pairs) p.off();
+    pairs = [];
+    if (container && container.parentNode) container.parentNode.removeChild(container);
+    container = null;
+    setPopupSuppressed(footnotes, false);
+    if (article) article.classList.remove("has-sidenotes");
+  }
+
+  function buildSidenotes() {
+    const article = getArticle();
+    if (!article) return;
+    const footnotes = getFootnotes(article);
+
+    if (!isWide() || footnotes.length === 0) {
+      clearSidenotes(article, footnotes);
+      return;
+    }
+
+    // Reset and rebuild from scratch.
+    for (const p of pairs) p.off();
+    pairs = [];
+    if (container && container.parentNode) container.parentNode.removeChild(container);
+
+    container = document.createElement("div");
+    container.className = CONTAINER_CLASS;
+    container.setAttribute("aria-hidden", "true");
+    article.appendChild(container);
+    article.classList.add("has-sidenotes");
+
+    const articleTop = article.getBoundingClientRect().top;
+    let prevBottom = -Infinity;
+
+    footnotes.forEach((fn, i) => {
+      if (!isVisible(fn)) return;
+
+      const note = document.createElement("div");
+      note.className = NOTE_CLASS;
+
+      const num = document.createElement("sup");
+      num.className = NOTE_CLASS + "-number";
+      num.textContent = getFootnoteNumber(fn, i);
+      note.appendChild(num);
+      note.appendChild(document.createTextNode(" "));
+
+      const body = document.createElement("span");
+      body.className = NOTE_CLASS + "-body";
+      for (const child of Array.from(fn.childNodes)) {
+        body.appendChild(child.cloneNode(true));
+      }
+      note.appendChild(body);
+
+      container.appendChild(note);
+
+      const wantTop = lineTop(fn, articleTop);
+      const top = Math.max(wantTop, prevBottom + SIDENOTE_GAP);
+      note.style.top = top + "px";
+      prevBottom = top + note.getBoundingClientRect().height;
+
+      const off = bindHoverPair(fn, note);
+      pairs.push({ fn, note, off });
+    });
+
+    setPopupSuppressed(footnotes, true);
+  }
+
+  function scheduleBuild() {
+    if (raf) cancelAnimationFrame(raf);
+    raf = requestAnimationFrame(() => {
+      raf = null;
+      buildSidenotes();
+    });
+  }
+
+  function init() {
+    const article = getArticle();
+    if (!article) return;
+
+    scheduleBuild();
+    window.addEventListener("resize", scheduleBuild);
+    window.addEventListener("load", scheduleBuild);
+
+    // Images, KaTeX, fonts, and figures load asynchronously and shift layout.
+    // Re-layout whenever the article's box height changes. The sidenote
+    // container is abspos so it doesn't affect the article's box, but guard
+    // against self-triggering anyway.
+    if (window.ResizeObserver) {
+      resizeObs = new ResizeObserver((entries) => {
+        const h = entries[0].contentRect.height;
+        if (Math.abs(h - lastArticleHeight) < 1) return;
+        lastArticleHeight = h;
+        scheduleBuild();
+      });
+      resizeObs.observe(article);
+    }
+
+    // Re-layout when collapsible answer blocks open/close.
+    article.addEventListener(
+      "toggle",
+      (e) => {
+        if (e.target && e.target.tagName === "DETAILS") scheduleBuild();
+      },
+      true
+    );
+  }
+
+  if (window.customElements && customElements.whenDefined) {
+    Promise.all([
+      customElements.whenDefined("d-footnote"),
+      new Promise((resolve) => {
+        if (document.readyState !== "loading") resolve();
+        else document.addEventListener("DOMContentLoaded", resolve, { once: true });
+      }),
+    ]).then(init);
+  } else {
+    document.addEventListener("DOMContentLoaded", init);
+  }
+})();

--- a/assets/js/sidenotes.js
+++ b/assets/js/sidenotes.js
@@ -52,9 +52,7 @@
           const style = document.createElement("style");
           style.setAttribute("data-sidenote", "");
           style.textContent =
-            "sup span." +
-            HOVER_CLASS +
-            "{color:#66b3ff;text-shadow:0 0 6px rgba(77,163,255,.9);}";
+            "sup span." + HOVER_CLASS + "{color:#ff8c00;}";
           root.appendChild(style);
         }
         hover.style.display = "none";

--- a/assets/js/sidenotes.js
+++ b/assets/js/sidenotes.js
@@ -82,12 +82,13 @@
     return r.width > 0 || r.height > 0;
   }
 
-  // Top of the text line containing the marker, relative to the article.
+  // Box of the text line containing the marker, relative to the article.
   // d-footnote is inline; its box height equals the line-height of the
   // surrounding text (the sup is position:relative so it doesn't grow the
-  // box), so rect.top is the line top.
-  function lineTop(fn, articleTop) {
-    return fn.getBoundingClientRect().top - articleTop;
+  // box), so rect.top/height are the line top/height.
+  function lineBox(fn, articleTop) {
+    const r = fn.getBoundingClientRect();
+    return { top: r.top - articleTop, height: r.height };
   }
 
   function setHoverPair(fn, note, on) {
@@ -172,7 +173,12 @@
 
       container.appendChild(note);
 
-      const wantTop = lineTop(fn, articleTop);
+      // Center the sidenote's first line on the body text line containing the
+      // marker, so the smaller sidenote text doesn't float above the body
+      // baseline (which is what raw top-to-top alignment gives).
+      const lb = lineBox(fn, articleTop);
+      const noteLH = parseFloat(getComputedStyle(note).lineHeight) || lb.height;
+      const wantTop = lb.top + (lb.height - noteLH) / 2;
       const top = Math.max(wantTop, prevBottom + SIDENOTE_GAP);
       note.style.top = top + "px";
       prevBottom = top + note.getBoundingClientRect().height;

--- a/assets/js/sidenotes.js
+++ b/assets/js/sidenotes.js
@@ -52,6 +52,7 @@
           const style = document.createElement("style");
           style.setAttribute("data-sidenote", "");
           style.textContent =
+            "sup span{cursor:pointer;}" +
             "sup span." + HOVER_CLASS + "{color:#ff8c00;}";
           root.appendChild(style);
         }
@@ -117,12 +118,14 @@
     };
     fn.addEventListener("mouseenter", on);
     fn.addEventListener("mouseleave", off);
+    fn.addEventListener("click", jump);
     note.addEventListener("mouseenter", on);
     note.addEventListener("mouseleave", off);
     note.addEventListener("click", jump);
     return () => {
       fn.removeEventListener("mouseenter", on);
       fn.removeEventListener("mouseleave", off);
+      fn.removeEventListener("click", jump);
       note.removeEventListener("mouseenter", on);
       note.removeEventListener("mouseleave", off);
       note.removeEventListener("click", jump);

--- a/assets/js/sidenotes.js
+++ b/assets/js/sidenotes.js
@@ -52,9 +52,7 @@
           const style = document.createElement("style");
           style.setAttribute("data-sidenote", "");
           style.textContent =
-            "sup span." +
-            HOVER_CLASS +
-            "{background:rgba(0,123,255,.18);border-radius:3px;padding:0 2px;}";
+            "sup span." + HOVER_CLASS + "{color:#0a58ca;}";
           root.appendChild(style);
         }
         hover.style.display = "none";

--- a/assets/js/sidenotes.js
+++ b/assets/js/sidenotes.js
@@ -39,6 +39,7 @@
     try {
       localStorage.setItem(PREF_KEY, on ? "1" : "0");
     } catch (e) {}
+    document.documentElement.classList.toggle("tufte-mode", on);
   }
 
   function getArticle() {
@@ -287,6 +288,9 @@
     const article = getArticle();
     if (!article) return;
 
+    // Sync class in case the early head script and the deferred script see
+    // different localStorage state (e.g. cleared mid-session).
+    document.documentElement.classList.toggle("tufte-mode", isEnabled());
     buildSettings();
     scheduleBuild();
     window.addEventListener("resize", scheduleBuild);

--- a/assets/js/sidenotes.js
+++ b/assets/js/sidenotes.js
@@ -15,6 +15,7 @@
   const CONTAINER_CLASS = "tufte-sidenotes";
   const NOTE_CLASS = "tufte-sidenote";
   const HOVER_CLASS = "tufte-hover";
+  const PREF_KEY = "tufte-sidenotes-enabled";
 
   let container = null;
   let pairs = []; // [{fn, note, off}]
@@ -24,6 +25,20 @@
 
   function isWide() {
     return window.matchMedia(WIDE_QUERY).matches;
+  }
+
+  function isEnabled() {
+    try {
+      return localStorage.getItem(PREF_KEY) === "1";
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function setEnabled(on) {
+    try {
+      localStorage.setItem(PREF_KEY, on ? "1" : "0");
+    } catch (e) {}
   }
 
   function getArticle() {
@@ -147,7 +162,7 @@
     if (!article) return;
     const footnotes = getFootnotes(article);
 
-    if (!isWide() || footnotes.length === 0) {
+    if (!isWide() || !isEnabled() || footnotes.length === 0) {
       clearSidenotes(article, footnotes);
       return;
     }
@@ -212,10 +227,67 @@
     });
   }
 
+  // Floating settings control (gear button + small popover with a checkbox).
+  // Only shown when the viewport is wide enough for sidenotes to be possible.
+  function buildSettings() {
+    const wrap = document.createElement("div");
+    wrap.className = "tufte-settings";
+
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "tufte-settings-btn";
+    btn.title = "Display settings";
+    btn.setAttribute("aria-haspopup", "true");
+    btn.setAttribute("aria-expanded", "false");
+    btn.innerHTML =
+      '<svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">' +
+      '<path fill="currentColor" d="M19.14 12.94a7.07 7.07 0 0 0 0-1.88l2.03-1.58a.5.5 0 0 0 ' +
+      ".12-.64l-1.92-3.32a.5.5 0 0 0-.6-.22l-2.39.96a7.03 7.03 0 0 0-1.62-.94l-.36-2.54a.5.5 " +
+      "0 0 0-.5-.42h-3.84a.5.5 0 0 0-.5.42l-.36 2.54c-.58.24-1.12.55-1.62.94l-2.39-.96a.5.5 " +
+      "0 0 0-.6.22L2.71 8.84a.5.5 0 0 0 .12.64l2.03 1.58a7.07 7.07 0 0 0 0 1.88l-2.03 " +
+      "1.58a.5.5 0 0 0-.12.64l1.92 3.32c.13.22.39.31.6.22l2.39-.96c.5.39 1.04.7 " +
+      "1.62.94l.36 2.54c.04.24.25.42.5.42h3.84c.25 0 .46-.18.5-.42l.36-2.54c.58-.24 " +
+      "1.12-.55 1.62-.94l2.39.96c.21.09.47 0 .6-.22l1.92-3.32a.5.5 0 0 0-.12-.64l-2.03-1.58zM12 " +
+      '15.5A3.5 3.5 0 1 1 12 8.5a3.5 3.5 0 0 1 0 7z"/></svg>';
+    wrap.appendChild(btn);
+
+    const panel = document.createElement("div");
+    panel.className = "tufte-settings-panel";
+    panel.hidden = true;
+    const id = "tufte-sidenotes-toggle";
+    panel.innerHTML =
+      '<label for="' + id + '">' +
+      '<input type="checkbox" id="' + id + '"> Tufte footnotes' +
+      "</label>";
+    wrap.appendChild(panel);
+
+    const cb = panel.querySelector("input");
+    cb.checked = isEnabled();
+    cb.addEventListener("change", () => {
+      setEnabled(cb.checked);
+      scheduleBuild();
+    });
+
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      panel.hidden = !panel.hidden;
+      btn.setAttribute("aria-expanded", String(!panel.hidden));
+    });
+    document.addEventListener("click", (e) => {
+      if (!panel.hidden && !wrap.contains(e.target)) {
+        panel.hidden = true;
+        btn.setAttribute("aria-expanded", "false");
+      }
+    });
+
+    document.body.appendChild(wrap);
+  }
+
   function init() {
     const article = getArticle();
     if (!article) return;
 
+    buildSettings();
     scheduleBuild();
     window.addEventListener("resize", scheduleBuild);
     window.addEventListener("load", scheduleBuild);

--- a/assets/js/sidenotes.js
+++ b/assets/js/sidenotes.js
@@ -106,15 +106,26 @@
   function bindHoverPair(fn, note) {
     const on = () => setHoverPair(fn, note, true);
     const off = () => setHoverPair(fn, note, false);
+    const jump = (e) => {
+      // Don't hijack clicks on links inside the sidenote.
+      if (e.target.closest("a")) return;
+      fn.scrollIntoView({ behavior: "smooth", block: "center" });
+      // Briefly flash the marker so it's findable once the mouse leaves the
+      // sidenote (which would otherwise immediately drop the highlight).
+      setHoverPair(fn, note, true);
+      setTimeout(off, 1200);
+    };
     fn.addEventListener("mouseenter", on);
     fn.addEventListener("mouseleave", off);
     note.addEventListener("mouseenter", on);
     note.addEventListener("mouseleave", off);
+    note.addEventListener("click", jump);
     return () => {
       fn.removeEventListener("mouseenter", on);
       fn.removeEventListener("mouseleave", off);
       note.removeEventListener("mouseenter", on);
       note.removeEventListener("mouseleave", off);
+      note.removeEventListener("click", jump);
       setHoverPair(fn, note, false);
     };
   }


### PR DESCRIPTION
On viewports ≥ 1000px, an understated gear button at the top-right opens a small panel with a "Tufte footnotes" checkbox. When enabled (default **off**, persisted in `localStorage` so it carries across pages):

**Layout**
- The left TOC is hidden and the distill grid's named `[text-start]`/`[text-end]`/`[gutter-*]` lines are redefined so the text column slides left to where the TOC was, with asymmetric outer margins (`0.6fr` left, `1fr` right). Everything that places itself with `grid-column: text` (article body, title, byline, appendix) moves automatically.
- The navbar and giscus comments get the same column template applied so they also align with the shifted text column.
- A tiny synchronous `<head>` script sets `html.tufte-mode` from localStorage before first paint, so there's no layout flicker.

**Sidenotes**
- Each `<d-footnote>` gets a sidenote in the right margin. The sidenote's first line is **centered on** the body text line containing the marker (not top-aligned, so the smaller font doesn't float above the body baseline). When markers are close together, later sidenotes push down to avoid overlap.
- Layout is rebuilt on `resize`, `<details>` toggle, and via a `ResizeObserver` on `d-article`, so positions stay correct as images/KaTeX/fonts load asynchronously.
- The native `d-hover-box` popup is suppressed while sidenotes are active (its `show()` is patched to a no-op since the component force-sets `display: block` on hover); restored when the toggle is off or the viewport is narrow.
- Footnotes inside collapsed `<details>` are skipped.

**Interaction**
- Hovering either the in-text marker or the sidenote flips both numbers to orange (a small style is injected into the `<d-footnote>` shadow root so the marker can be reached). Pure `color` change, no layout shift.
- Clicking either side smooth-scrolls to center the marker's line and holds the highlight ~1.2s. Links inside the sidenote still work normally.

**Files**
- `assets/js/sidenotes.js` — new
- `_sass/_distill.scss` — sidenote/tufte-mode/settings styles (all `@media (min-width: 1000px)`-scoped)
- `_includes/distill_scripts.liquid` — `<script defer>` tag
- `_includes/head.liquid` — pre-paint `html.tufte-mode` setter

**Known limitation**: full-width figures that extend into the gutter will overlap sidenotes at the same vertical position.

(16 commits — squash-merge.)