### PR TITLE
Update Colab TensorBoard profiler install instructions

### DIFF
--- a/profiling.md
+++ b/profiling.md
@@ -132,7 +132,8 @@ with jax.profiler.trace("/tmp/tensorboard"):
 
 # Now you can load TensorBoard in a Google Colab with
 #
-# !pip install tensorboard tensorboard-plugin-profile
+# !pip install -U xprof
+# !pip install -U protobuf
 # %load_ext tensorboard
 # %tensorboard --logdir=/tmp/tensorboard
 #


### PR DESCRIPTION
Reported by a reader: the old `pip install tensorboard tensorboard-plugin-profile` flow no longer works with current Colab runtimes (the plugin versions are incompatible with the runtime). The profile plugin is now provided by `xprof`, and an upgraded `protobuf` is required.

Updated the comment in the `jax.profiler.trace` example in `profiling.md`:

```
# !pip install -U xprof
# !pip install -U protobuf
# %load_ext tensorboard
# %tensorboard --logdir=/tmp/tensorboard
```

`%load_ext tensorboard` still works as before; `tensorboard-plugin-profile` is no longer needed.