### PR TITLE
Add TPU7x to spec tables; fix wide-table scrolling on mobile

### DIFF
--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -303,9 +303,16 @@ mjx-container {
     display: none;
   }
 
+  // Let wide tables (e.g. the TPU spec tables) scroll horizontally instead
+  // of squishing to the viewport width. display: block makes the table its
+  // own scroll container; fit-content keeps narrow tables narrow while
+  // capping wide ones at the viewport so the overflow scrolls.
   d-article table {
-    width: 100%;
-    min-width: 100%;
+    display: block;
+    width: fit-content;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   // Keep navbar expanded on small screens

--- a/tpus.md
+++ b/tpus.md
@@ -125,7 +125,7 @@ A matmul would look nearly identical except it would load into the MXU instead o
 
 {% include figure.liquid path="assets/img/tpu-bandwidth.png" class="img-fluid" %}
 
-**A TPU chip typically (but not always) consists of two TPU cores which share memory and can be thought of as one large accelerator** with twice the FLOPs (known as a "megacore" configuration). This has been true since TPU v4. Older TPU chips have separate memory and are regarded as two separate accelerators (TPU v3 and older). Inference-optimized chips like the TPU v5e only have one TPU core per chip.
+**A TPU chip typically (but not always) consists of two TPU cores which share memory and can be thought of as one large accelerator** with twice the FLOPs (known as a "megacore" configuration). This is true for v4, v5, and v6 TPUs (TPU v7 removes megacore and instead has a high-bandwidth link between the two cores). Older TPU chips have separate memory and are regarded as two separate accelerators (TPU v3 and older). Inference-optimized chips like the TPU v5e only have one TPU core per chip.
 
 {% include figure.liquid path="assets/img/cores.png" class="img-fluid img-small" %}
 
@@ -161,7 +161,7 @@ TPU v5e and Trillium pods consist of a single `16x16` 2D torus with wraparounds 
 
 * `2.8e12` bytes/s (2.8 TB/s) of HBM bandwidth per chip.
 * `9e10` bytes/s (90 GB/s) of ICI bandwidth per axis, with 3 axes per chip.<d-footnote>The page above lists 100 GB/s of bandwidth, which is slightly different from what's listed here. TPU ICI links have slightly different bandwidths depending on the operation being performed. You can generally use the numbers in this doc without worry.</d-footnote>
-* `6.25e9` bytes/s (6.25 GB/s) of DCN (egress) bandwidth per TPU (via 1-2 NICs on each host).<d-footnote>TPU v6e has 12.5e9 bytes/s and v5e has 3.125e9 bytes/s.</d-footnote>
+* `6.25e9` bytes/s (6.25 GB/s) of DCN (egress) bandwidth per TPU (via 1-2 NICs on each host).<d-footnote>TPU v6e and TPU7x have 12.5e9 bytes/s and v5e has 3.125e9 bytes/s.</d-footnote>
 
 This means that when we split models across multiple chips, we need to be careful to avoid bottlenecking the MXU with slower cross-device communication.
 
@@ -196,8 +196,9 @@ Here are some specific numbers for our chips:
 | <span class="nowrap-header">TPU v5p</span> | 16x20x28 |   2x2x1   |       96GB        |        2.8e12         |       4.59e14       |       9.18e14       |
 | <span class="nowrap-header">TPU v5e</span> |  16x16   |    4x2    |       16GB        |        8.2e11         |       1.97e14       |       3.94e14       |
 | <span class="nowrap-header">TPU v6e</span> |  16x16   |    4x2    |       32GB        |        1.6e12         |       9.20e14       |       1.84e15       |
+| <span class="nowrap-header">TPU7x</span>   | 4x4x144  |   2x2x1   |       192GB       |        7.4e12         |       2.30e15       |       4.61e15       |
 
-Host size refers to the topology of TPUs connected to a single host (e.g. TPU v5e has a single CPU host connected to 8 TPUs in a 4x2 topology). Here are interconnect figures:
+Host size refers to the topology of TPUs connected to a single host (e.g. TPU v5e has a single CPU host connected to 8 TPUs in a 4x2 topology). See the [TPU7x documentation](https://docs.cloud.google.com/tpu/docs/tpu7x) for more details on the latest generation. Here are interconnect figures:
 
 | Model       | ICI BW/link (one-way, bytes/s) | ICI BW/link (bidi, bytes/s) |
 | :---------- | :----------------------------: | :-------------------------: |
@@ -206,10 +207,11 @@ Host size refers to the topology of TPUs connected to a single host (e.g. TPU v5
 | **TPU v5p** |             9.0e10             |           1.8e11            |
 | **TPU v5e** |             4.5e10             |           9.0e10            |
 | **TPU v6e** |             9.0e10             |           1.8e11            |
+| **TPU7x**   |             9.0e10             |           1.8e11            |
 
 We include both one-way (unidirectional) bandwidth and bidi (bidirectional) bandwidth since unidirectional bandwidth is more true to the hardware but bidirectional bandwidth occurs more often in equations involving a full ring.<d-footnote>By bidi (bidirectional) bandwidth we mean the total bytes that can be sent along a single link in both directions, or equally, the total number of outgoing bytes from a single TPU along a particular axis, assuming we can use both links efficiently. This is true when we have a functioning ring, AKA when we have a wraparound connection on the particular axis. This occurs on inference chips when we have a full 16 axis, or on training chips (v*p) when we have an axis which is a multiple of 4. We prefer to use the bidirectional bandwidth because it appears frequently in calculations involving bidirectional comms.</d-footnote>
 
-PCIe bandwidth is typically around `1.6e10` bytes / second per TPU (`3.2e10` for TPU v6e), while DCN bandwidth is typically around `6.25e9` bytes / second per TPU (`12.5e9` for TPU v6e and `3.125e9` for TPU v5e).
+PCIe bandwidth is typically around `1.6e10` bytes / second per TPU (`3.2e10` for TPU v6e), while DCN bandwidth is typically around `6.25e9` bytes / second per TPU (`12.5e9` for TPU v6e and TPU7x, and `3.125e9` for TPU v5e).
 
 ## Worked Problems
 


### PR DESCRIPTION
## TPU7x (Ironwood) spec tables

Added TPU7x rows to both tables in the TPUs chapter, with values cross-checked against the [TPU7x docs](https://docs.cloud.google.com/tpu/docs/tpu7x):

| field | value |
|---|---|
| Pod size | 4x4x144 |
| Host size | 2x2x1 |
| HBM/chip | 192GB |
| HBM BW/chip | 7.4e12 (7.37 TB/s) |
| bf16 FLOPs/s/chip | 2.30e15 (2307 TFLOP/s) |
| int8/fp8 OPs/s/chip | 4.61e15 (4614 TFLOP/s) |
| ICI BW/link | 9.0e10 one-way / 1.8e11 bidi |
| DCN | 12.5e9 (100 Gbps) |

ICI matches v5p exactly: the docs list both v5p and TPU7x at 1,200 GB/s per-chip bidirectional, and both are 3D tori, so the per-link figures are identical. Linked the TPU7x docs in the paragraph below the spec table.

## Megacore note

Updated "This has been true since TPU v4." → megacore holds for v4/v5/v6, and TPU v7 removes megacore in favor of a high-bandwidth link between the two cores.

## Mobile table scrolling

Wide tables (notably the TPU spec tables) were being squished to the viewport width on small screens (the old rule forced `width: 100%; min-width: 100%`). They now scroll horizontally instead (`display: block; width: fit-content; max-width: 100%; overflow-x: auto`), so columns keep their natural width.