### PR TITLE
Fix table clipping on narrow Safari viewports

### DIFF
--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -305,11 +305,14 @@ mjx-container {
 
   // Let wide tables (e.g. the TPU spec tables) scroll horizontally instead
   // of squishing to the viewport width. display: block makes the table its
-  // own scroll container; fit-content keeps narrow tables narrow while
-  // capping wide ones at the viewport so the overflow scrolls.
+  // own scroll container; min-width: 0 lets it shrink to the grid column
+  // (Safari/WebKit doesn't auto-apply the scroll-container minimum, so without
+  // this the table's content width blows out the text column and the page
+  // content gets clipped). max-width caps it at the column so overflow scrolls.
   d-article table {
     display: block;
-    width: fit-content;
+    width: auto;
+    min-width: 0;
     max-width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
On viewports below 576px, Safari/WebKit clips the page content in the TPUs chapter (the spec tables' right columns get cut off rather than scrolling), while Chrome renders fine.

**Cause:** the responsive-table rule added in #115 used `width: fit-content` on the `display: block` table. The table is a CSS grid item (`d-article > * { grid-column: text }`). In WebKit, `fit-content` makes the block keep its full content width instead of shrinking to the text column, and WebKit doesn't apply the automatic scroll-container minimum here — so the table's content width blows out the `text` grid track and the surrounding page content gets clipped by an ancestor.

**Fix:** replace `width: fit-content` with `width: auto; min-width: 0`. `min-width: 0` is the standard way to let a grid item shrink below its content size; combined with `max-width: 100%` and `overflow-x: auto`, the table shrinks to the column and its overflow scrolls instead. Numeric tables (unbreakable tokens like `2.30e15`) still scroll; prose tables still wrap.

Verified in a WebKit engine (Bun WKWebView) at 375/500px that the table fits its column and scrolls internally with no page-level overflow.