### PR TITLE
Reserve byline height to prevent load-time reflow

### DIFF
--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -4,6 +4,18 @@
 
 d-byline {
   border-top-color: var(--global-divider-color) !important;
+  // The byline (author list) is populated by the distill JS after load, which
+  // grows it from ~one line to the full author grid and reflows everything
+  // below. Reserve its rendered height up front so the page doesn't jump. The
+  // author grid is 2 columns below 768px (taller) and 4 columns above.
+  box-sizing: border-box;
+  min-height: 236px;
+}
+
+@media (min-width: 768px) {
+  d-byline {
+    min-height: 210px;
+  }
 }
 
 d-byline h3 {


### PR DESCRIPTION
The author byline (`<d-byline>`) is empty in the HTML and populated by the distill JS after load. It grows from ~one line to the full author grid, which reflows everything below it — a visible jump on every page load.

**Fix:** reserve the byline's rendered height with `min-height` up front (with `box-sizing: border-box` so the value includes its padding/border):
- `236px` for the 2-column author grid below 768px
- `210px` for the 4-column grid at ≥768px

Measured the rendered heights across widths (stable per breakpoint). `min-height` only sets a floor, so it can't clip the content if it's ever slightly taller. Verified against the live byline that the reserved height matches the rendered author grid exactly (no gap, no clipping).