### PR TITLE
Fix v5p DCN arithmetic intensity (4.46e14 -> 4.59e14)

### DIFF
--- a/training.md
+++ b/training.md
@@ -581,7 +581,7 @@ The comms bandwidth scales with $M$, since unlike ICI the total bandwidth grows 
 
 $$\frac{B}{\text{slice}} > \frac{C}{W_\text{dcn}}$$
 
-For TPU v5p, the $\frac{C}{W_\text{dcn}}$ is about `4.46e14 / 6.25e9 = 71,360`. This tells us that to efficiently scale over DCN, there is a minimum batch size per ICI domain needed to egress each node.
+For TPU v5p, the $\frac{C}{W_\text{dcn}}$ is about `4.59e14 / 6.25e9 = 73,440`. This tells us that to efficiently scale over DCN, there is a minimum batch size per ICI domain needed to egress each node.
 
 **How much of a problem is this?** To take a specific example, say we want to train LLaMA-3 70B on TPU v5p with a BS of 2M tokens. LLaMA-3 70B has $F\approx 30,000$. From the above sections, we know the following:
 
@@ -589,9 +589,9 @@ For TPU v5p, the $\frac{C}{W_\text{dcn}}$ is about `4.46e14 / 6.25e9 = 71,360`. 
 * We can do FSDP so long as $B / N > 2550 / M_X$. That means if we want to train with BS=2M and 3 axes of data parallelism, we'd at most be able to use $\approx 2400$ chips, roughly a quarter of a TPU v5p pod.
 * When we combine FSDP + Tensor Parallelism, become comms-bound when we have $B / N < 2550^2 / (2 \cdot 30000) = 108$, so this lets us scale to roughly 18k chips! However, the maximum size of a TPU v5p pod is 8k chips, so beyond that we have to use DCN.
 
-The TLDR is that we have a nice recipe for training with BS=1M, using roughly X (FSDP) = 1024 and Y (TP) = 8, but with BS=2M we need to use DCN. As noted above, we have a DCN arithmetic intensity of $\text{71,360}$, so we just need to make sure our batch size per ICI domain is greater than this. This is trivial for us, since with 2 pods we'd have a per-pod BS of 1M, and a per TPU batch size of 111, which is great (maybe cutting it a bit close, but theoretically sound).
+The TLDR is that we have a nice recipe for training with BS=1M, using roughly X (FSDP) = 1024 and Y (TP) = 8, but with BS=2M we need to use DCN. As noted above, we have a DCN arithmetic intensity of $\text{73,440}$, so we just need to make sure our batch size per ICI domain is greater than this. This is trivial for us, since with 2 pods we'd have a per-pod BS of 1M, and a per TPU batch size of 111, which is great (maybe cutting it a bit close, but theoretically sound).
 
-<p markdown=1 class="takeaway">**Takeaway:** Scaling across multiple TPU pods is fairly straightforward using pure data parallelism so long as our per-pod batch size is at least 71k tokens.</p>
+<p markdown=1 class="takeaway">**Takeaway:** Scaling across multiple TPU pods is fairly straightforward using pure data parallelism so long as our per-pod batch size is at least 73k tokens.</p>
 
 ## Takeaways from LLM Training on TPUs
 


### PR DESCRIPTION
In the "Scaling Across Pods" section of the training chapter, the DCN arithmetic intensity calculation used 4.46e14 for TPU v5p peak FLOPs/s, inconsistent with the 4.59e14 figure used elsewhere in the chapter (and in the TPU spec tables).

Updates the calculation to `4.59e14 / 6.25e9 = 73,440` and the two downstream references (the restated intensity and the "71k tokens" takeaway, now 73k). The surrounding LLaMA-3 example is unaffected since the per-pod batch size of 1M still far exceeds the threshold.