### PR TITLE
Fix reader-reported errata in the GPU and profiling chapters

### DIFF
--- a/gpus.md
+++ b/gpus.md
@@ -307,9 +307,9 @@ Here are some more Q/A problems on networking. I find these particularly useful 
 
 {% details Click here for the answer. %}
 
-**Answer:** Each GPU can egress 450GB/s, and each GPU has $B / N$ bytes (where `N=8`, the node size). We can imagine each node sending its bytes to each of the other $N - 1$ nodes one after the other, leading to a total of (N - 1) turns each with $T_\text{comms} = (B / (N * W_\text{unidirectional}))$, or $T_\text{comms} = (N - 1) * B / (N * W_\text{unidirectional})$. This is approximately $B / (N * W_\text{uni})$ or $B / \text{3.6e12}$, the bisection bandwidth.
+**Answer:** Each GPU can egress 450GB/s, and each GPU has $B / N$ bytes (where `N=8`, the node size). We can imagine each node sending its bytes to each of the other $N - 1$ nodes one after the other, leading to a total of (N - 1) turns each with $T_\text{comms} = (B / (N * W_\text{unidirectional}))$, or $T_\text{comms} = (N - 1) * B / (N * W_\text{unidirectional})$. This is approximately $B / W_\text{uni}$ or $B / \text{450e9}$.
 
-For the given array, we have `B=4096 * 65536 * 2=512MB`, so the total time is `536e6 * (8 - 1) / 3.6e12 = 1.04ms`. This could be latency-bound, so it may take longer than this in practice (in practice it takes about 1.5ms).
+For the given array, we have `B = 4096 * 65536 * 2 = 536e6` bytes, so the total time is `536e6 * (8 - 1) / (8 * 450e9) = 1.04ms` (or `536e6 / 450e9 = 1.19ms` with the approximation). This could be latency-bound, so it may take longer than this in practice (in practice it takes about 1.5ms).
 
 {% enddetails %}
 
@@ -420,7 +420,7 @@ $(N-1)/N \cdot \min(k/N, 1) \cdot B / (W \cdot N)$.<d-footnote>The true cost is 
 
 {% details Click here for the answer. %}
 
-**Answer:** From the above, we know that in the dense case, the cost is $B \cdot (N-1) / (W \cdot N^2)$, or $B / (W \cdot N)$. If we know only $\frac{1}{2}$ the entries will be non-padding, we can send $B \cdot k/N / (W \cdot N) = B / (2 \cdot W \cdot N)$, roughly half the overall cost.
+**Answer:** Note that here $B$ is the batch dimension of the array, so the total array size is $V = 2 \cdot B \cdot N$ bytes. From the above, we know that in the dense case, the cost is $V \cdot (N-1) / (W \cdot N^2)$, or roughly $V / (W \cdot N)$. If we know only $\frac{1}{2}$ the entries will be non-padding, we can send $V \cdot k/N / (W \cdot N) = V / (2 \cdot W \cdot N)$, roughly half the overall cost.
 
 {% enddetails %}
 

--- a/profiling.md
+++ b/profiling.md
@@ -278,7 +278,7 @@ which tells us the per-shard shape is `bf16[8192] * bf16[4096, 8192] -> bf16[409
 
 {% enddetails %}
 
-**Question 2:** [The Transformer Colab from earlier](https://colab.research.google.com/drive/1_6krERgtolH7hbUIo7ewAMLlbA4fqEF8?usp=sharing) implements a simple mock Transformer. Since Colab no longer provides TPU v2-8 slices, you'll want to run this on [Kaggle](https://www.kaggle.com/) or an 8-core GCP slice to follow along. Follow the instructions in the Colab and get a benchmark of the naive Transformer with GSPMD partitioning. How long does each part take? How long should it take? What sharding is being used? Try fixing the sharding! *Hint: use `jax.lax.with_sharding_constraint` to constrain the behavior. With this fix, what's the best MXU you can get?*
+**Question 2:** [The Transformer Colab from earlier](https://colab.research.google.com/drive/1_6krERgtolH7hbUIo7ewAMLlbA4fqEF8?usp=sharing) implements a simple mock Transformer. Since Colab no longer provides TPU v2-8 slices, you'll want to run this on [Kaggle](https://www.kaggle.com/) or an 8-core GCP slice to follow along. Follow the instructions in the Colab and get a benchmark of the naive Transformer with GSPMD partitioning. How long does each part take? How long should it take? What sharding is being used? Try fixing the sharding! *Hint: use `jax.lax.with_sharding_constraint` to constrain the behavior. With this fix, what's the best MFU you can get?*
 
 For reference, the initial version gets roughly 184ms / layer and the optimized profile gets 67ms / layer. Once you've done this, try staring at the profile and see if you can answer these questions purely from the profile:
 


### PR DESCRIPTION
Three fixes for issues readers called out:

- **Quiz 2 Q3 [AllGather cost]** (gpus.md): $(N-1) \cdot B / (N \cdot W_\text{uni})$ approximates to $B / W_\text{uni}$, not $B / (N \cdot W_\text{uni})$, and the result is not the bisection bandwidth. The numerics now show both the exact formula (with the denominator spelled out as `8 * 450e9`) and the approximation.
- **Pop Quiz 2 [AllToAll time]** (gpus.md): the question's `bf16[B_X, N]` array uses B as a dimension, but the answer plugged B into formulas where B means total bytes. The answer now introduces $V = 2BN$ total bytes and carries it through.
- **Profiling Question 2**: "best MXU" → "best MFU" (MXU is the hardware unit; MFU is the utilization metric used throughout the book).

🤖 Generated with [Claude Code](https://claude.com/claude-code)