### PR TITLE
docs: add Jacob's AI Chip Architectures blog to further reading

### DIFF
--- a/conclusion.md
+++ b/conclusion.md
@@ -122,6 +122,7 @@ There is a bunch of related writing, including the following:
 - [**Stas Bekman's ML Engineering Handbook**](https://github.com/stas00/ml-engineering): a highly practical guide to ML infrastructure, covering topics not addressed in this book like how to negotiate with cloud providers, cluster management, and empirical measurements of GPU throughput.
 - [**ezyang's blog**](https://blog.ezyang.com/2026/01/computing-sharding-with-einsum/): a PyTorch lead's blog on all things sharding + PyTorch, including a [guide to PyTorch internals](https://blog.ezyang.com/2019/05/pytorch-internals/) and a [writeup of sharded matrix multiplication](https://blog.ezyang.com/2026/01/computing-sharding-with-einsum/). Lots of other good things here.
 - [**The Anatomy of Collective Communication**](https://www.aleksagordic.com/blog/collective-operations): a nice walkthrough of GPU and TPU collectives in the spirit of this book. Has a better writeup of N-D and GPU collectives than this book.
+- [**AI Chip Architectures**](https://www.jepeake.com/ai-chip-architectures): a really good blog explaining the architectures of all major accelerator hardware: TPUs, NVIDIA GPUs, AMD GPUs, AWS Trainium, Cerebras, Groq.
 
 There remains a lot of room for comprehensive writing in this area, so we hope this manuscript encourages more of it! We also believe that this is a fruitful area to study and research. In many cases, it can be done even without having many hardware accelerators on hand.
 


### PR DESCRIPTION
This PR adds a recommendation for the "AI Chip Architectures" blog post by Jacob Peake to the Further Reading section in `conclusion.md`. 
The blog provides a comprehensive and accessible explanation of the major accelerator hardware architectures relevant to scaling, including:
- TPUs
- NVIDIA and AMD GPUs
- AWS Trainium
- Cerebras and Groq
It serves as an excellent supplementary resource for readers looking to understand the underlying hardware landscape that powers the scaling techniques discussed in this book.

LInk to the blog: https://www.jepeake.com/ai-chip-architectures