### PR TITLE
Use float dtype to prevent integer overflow

### DIFF
--- a/roofline.md
+++ b/roofline.md
@@ -228,7 +228,7 @@ Note that both models eventually achieve the peak hardware FLOPs/s, but the larg
 import matplotlib.pyplot as plt
 import numpy as np
 
-bs = np.arange(1, 512)
+bs = np.arange(1, 512, dtype=np.float64)
 
 def roofline(B, D, F):
   total_flops = 2*B*D*F


### PR DESCRIPTION
Without this, we might get sawtooth plot like below

<img width="2188" height="830" alt="result" src="https://github.com/user-attachments/assets/00e71c47-2e27-4971-8e2e-9dd34600b6e1" />
